### PR TITLE
MTM Site Homepage Redirect Fix

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ theme:
   features:
     - navigation.sections
 extra: 
-  homepage: https://azure.microsoft.com/
+  homepage: https://microsoft.github.io/Mastering-the-Marketplace/
   analytics:
     provider: google
     property: G-XXXXXXXXXX # Use production Property ID here


### PR DESCRIPTION
This fixes the redirection to the Azure Website to the Mastering the Marketplace site