### PR TITLE
Minor fixes discovered during my self-paced walkthrough of the labs

### DIFF
--- a/docs/container/Labs/lab1-prepare-container-deployment/index.md
+++ b/docs/container/Labs/lab1-prepare-container-deployment/index.md
@@ -56,7 +56,7 @@ This section is extrememly important for working easily through the labs.
 
 You will be working with one solution throughout all the labs. To make it easier to work with the solution, you will make a copy of the solution folder and move it to a location of your choice outside the Git repository folder that holds these labs.
 
-1. Copy the folder `<path to Git repo>/docs/container/lab1-prepare-container-deployment/begin`.
+1. Copy the folder `<path to Git repo>/docs/container/Labs/lab1-prepare-container-deployment/begin`.
 2. Copy this folder to a location of your choice. `c:\projects\begin` for example.
 3. Rename the `begin` folder to `container-labs`.
 4. From now on, the labs will refer to `container-labs` when referring to your working folder.

--- a/docs/container/Labs/lab3-publishing-container-offer/index.md
+++ b/docs/container/Labs/lab3-publishing-container-offer/index.md
@@ -57,7 +57,7 @@ Navigate to the **Properties** tab on the left.
 
 ### Categories
 
-You must select at least one category for your offer. COntainer offers must be mapped as below so they are displayed in the right place in the marketplace.
+You must select at least one category for your offer. Container offers must be mapped as below so they are displayed in the right place in the marketplace.
 
 1. Click the **+ Categories** link.
 1. In the left dropdown, select **Containers**.

--- a/docs/container/Labs/prerequisites/acr.md
+++ b/docs/container/Labs/prerequisites/acr.md
@@ -61,7 +61,7 @@ The Azure Marketplace will host your CNAB in a Marketplace special ACR of its ow
 
 2. Get the ID of your ACR.
 
-        az acr show --name <ACR Server> --query "id" --output tsv
+        az acr show --resource-group myResourceGroup --name <ACR Server> --query "id" --output tsv
 
     Note the full ID for the use in the following steps.
 


### PR DESCRIPTION
1. The `az acr show` command does not find the ACR if the resource group name is not the same as the ACR name. This PR adds the required command line argument to the lab for this scenario.

2. Fixed the path to the source code files to include the `/Labs/` part of the path.

Signed-off-by: Stuart Preston <mail@stuartpreston.net>